### PR TITLE
Update environment.yml to update plotly to 6.0.0 from 5.8.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - ipykernel=6.12.1
   - dash=2.18*
   - dash-bootstrap-components=1.7.*
-  - plotly=5.8.0
+  - plotly=6.0.0
   - tabulate=0.8.9
   - lxml=4.8.0
   - altair=5.5.*


### PR DESCRIPTION
Update the plotly environment to remove warnings in console when running dashboard. Tested new environment on my machine and it builds properly and successfully runs the dashboard with no warnings.