### PR TITLE
feat: Improve dashboard layout

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -6,7 +6,8 @@ from .components import (
     age_pie_chart,
     collapse_button,
     crime_bar_chart,
-    footer_component,
+    footer_toggle_button,
+    footer_content,
     gender_pie_chart,
     map_chart,
     sidebar,
@@ -38,7 +39,10 @@ app.layout = dbc.Container([
             ])
         ], md=6)
     ]),
-    dbc.Row(dbc.Col(footer_component, width=12))
+    dbc.Row(footer_toggle_button),
+    html.Br(),
+    html.Br(),
+    dbc.Row(dbc.Col(footer_content, width=12))
 ], fluid=True)
 
 # Run the app/dashboard

--- a/src/app.py
+++ b/src/app.py
@@ -1,5 +1,5 @@
 import dash_bootstrap_components as dbc
-from dash import Dash
+from dash import Dash, html
 
 from . import callbacks
 from .components import (
@@ -27,16 +27,20 @@ app.layout = dbc.Container([
     ]),
     sidebar,
     dbc.Row([
-        dbc.Col(map_chart, md=8),
+        dbc.Col(map_chart, md=6),
         dbc.Col([
-            crime_bar_chart,  
-            gender_pie_chart,
-            age_pie_chart
-        ], md=4)
+            crime_bar_chart,
+            html.Br(),
+            html.Br(),
+            dbc.Row([
+                dbc.Col(gender_pie_chart, md=6),
+                dbc.Col(age_pie_chart, md=6)
+            ])
+        ], md=6)
     ]),
     dbc.Row(dbc.Col(footer_component, width=12))
 ], fluid=True)
 
 # Run the app/dashboard
 if __name__ == '__main__':
-    server.run()
+    app.run()

--- a/src/callbacks/map.py
+++ b/src/callbacks/map.py
@@ -99,7 +99,7 @@ def create_map_chart(
     map_chart = alt.Chart(
         geo_df,
         width=600,
-        height=500,
+        height=450,
         title=map_title
     ).mark_geoshape(
         stroke='grey'

--- a/src/components/__init__.py
+++ b/src/components/__init__.py
@@ -1,3 +1,5 @@
-from .general import title_comp, collapse_button, sidebar, footer_component
+from .general import (
+    title_comp, collapse_button, sidebar, footer_toggle_button, footer_content
+)
 from .charts import crime_bar_chart, gender_pie_chart, age_pie_chart
 from .map import map_chart

--- a/src/components/general.py
+++ b/src/components/general.py
@@ -118,7 +118,7 @@ sidebar = dbc.Collapse(
             "left": 0,  # Always aligned to the left
             "width": "375px",
             "height": "100vh",
-            "background-color": "#e6e6e6",
+            "background-color": "rgba(230, 230, 230, 0.85)",
             "padding": "20px",
             "z-index": "1000",  # Keep sidebar above content
             "overflow-y": "auto"  # Allow scrolling if many options

--- a/src/components/general.py
+++ b/src/components/general.py
@@ -128,19 +128,23 @@ sidebar = dbc.Collapse(
     is_open=False,  # Start collapsed
 )
 
-footer_toggle_button = dbc.Button(
-    "About ▼",
-    id="footer-toggle-button",
-    color="light",
-    size="sm",
-    className="my-2",
+footer_toggle_button = dbc.Col(
+    dbc.Button(
+        "About ▼",
+        id="footer-toggle-button",
+        color="light",
+        size="sm",
+        style={
+            'width': '120px',
+            'background-color': 'steelblue',
+            'color': 'white',
+            'margin-top': 10
+        }
+    ),
+    width="auto",
     style={
-        'margin': '10px auto',
-        'display': 'block',
-        'width': '120px',
-        'background-color': 'steelblue',  
-        'color': 'white',                 
-        'border': 'none',  
+        "position": "absolute",
+        "right": "20px",
     }
 )
 
@@ -203,11 +207,6 @@ footer_content = dbc.Collapse(
     id="footer-collapse",
     is_open=False
 )
-
-footer_component = html.Div([
-    footer_toggle_button,
-    footer_content
-], className="mt-3 mb-4")
 
 # Title
 title_comp = html.H1(

--- a/src/components/map.py
+++ b/src/components/map.py
@@ -10,5 +10,5 @@ map_chart = dbc.Col(
             signalsToObserve=['select_region']
         )]
     ),
-    md=8
+    md=6
 )


### PR DESCRIPTION
Improvements to the dashboard layout so it all appears cleanly on 1 screen:

- Map and charts now each take up half the width of the screen instead of 2/3rds map and 1/3rd charts
- Pie charts are now in same row instead of all being in one column with bar chart
- Made sidebar slightly transparent so viewer can see under sidebar
- Moved about button to the right side of the screen
- Reduced the height of the map slightly so it appears on 1 page now

Closes #121