### PR TITLE
fix: pie title cutoff

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -32,7 +32,6 @@ app.layout = dbc.Container([
         dbc.Col([
             crime_bar_chart,
             html.Br(),
-            html.Br(),
             dbc.Row([
                 dbc.Col(gender_pie_chart, md=6),
                 dbc.Col(age_pie_chart, md=6)

--- a/src/callbacks/charts.py
+++ b/src/callbacks/charts.py
@@ -38,10 +38,13 @@ def update_all_pie_charts(
     # Format crime types for display
     if not crime_types:
         crime_type_display = ""
+        pie_sep = ""
     elif len(crime_types) == 1:
         crime_type_display = f" - {crime_types[0]}"
+        pie_sep = "<br>"
     else:
         crime_type_display = f" - Selected Crimes ({len(crime_types)})"
+        pie_sep = "<br>"
 
     # Apply filter ONLY if the apply button was clicked
     if triggered_id == "apply-button" or triggered_id == "map":
@@ -119,12 +122,12 @@ def update_all_pie_charts(
     # Create charts with pre-computed data
     updated_gender_chart = create_pie_chart(
         gender_counts,
-        f"Arrests by Gender{location_label_display}{crime_type_display}"
+        f"Arrests by Gender{location_label_display}{pie_sep}{crime_type_display}"
     )
 
     updated_age_chart = create_pie_chart(
         age_counts,
-        f"Arrests by Age Group{location_label_display}{crime_type_display}"
+        f"Arrests by Age Group{location_label_display}{pie_sep}{crime_type_display}"
     )
 
     return updated_crime_chart, updated_gender_chart, updated_age_chart

--- a/src/callbacks/charts.py
+++ b/src/callbacks/charts.py
@@ -1,5 +1,4 @@
 from dash import Output, Input, State, callback, callback_context
-import pandas as pd
 
 from src.data import nyc_arrests
 from src.utils import (
@@ -8,9 +7,7 @@ from src.utils import (
     filter_data_by_location,
     create_pie_chart,
     create_bar_chart,
-    filter_data_by_date_range,
-    filter_data_by_crime_type,
-    create_empty_pie_chart, 
+    create_empty_pie_chart,
     create_empty_bar_chart
 )
 

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -241,13 +241,13 @@ def create_pie_chart(data, title):
         ),
         uniformtext_minsize=12,
         uniformtext_mode='hide',
-        height=190,  
-        margin=dict(l=10, r=10, t=30, b=10),  
+        height=220,  
+        margin=dict(l=10, r=10, t=50, b=10),  
         title=dict(
             text=title,
             font=dict(size=14),  
             x=0.5, 
-            y=0.95  
+            y=0.90  
         )
     )
     return pie_chart
@@ -279,8 +279,8 @@ def create_empty_pie_chart():
     # Remove legend and add no data message to pie chart
     pie_chart.update_layout(
         showlegend=False,
-        height=190,
-        margin=dict(l=10, r=10, t=30, b=10),
+        height=220,
+        margin=dict(l=10, r=10, t=50, b=10),
         annotations=[dict(
             text="No Data",
             x=0.5,
@@ -291,7 +291,7 @@ def create_empty_pie_chart():
             text="No Data",
             font=dict(size=14),
             x=0.5,
-            y=0.95
+            y=0.90
         )
     )
 
@@ -389,6 +389,6 @@ def create_empty_bar_chart():
                 y=0.5
             )
         ],
-        height=300
+        height=240
     )
     return fig

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -274,7 +274,9 @@ def create_empty_pie_chart():
     )
 
     # Hide labels and percentage values
-    pie_chart.update_traces(textinfo="none", hoverinfo="none")
+    pie_chart.update_traces(
+        textinfo="none", hoverinfo="skip", hovertemplate=None
+    )
 
     # Remove legend and add no data message to pie chart
     pie_chart.update_layout(
@@ -379,6 +381,7 @@ def create_empty_bar_chart():
 
     fig.update_layout(
         title="No Data Available",
+        dragmode=False,
         annotations=[
             dict(
                 text="No data available for the selected filters",
@@ -389,6 +392,12 @@ def create_empty_bar_chart():
                 y=0.5
             )
         ],
+        yaxis=dict(
+            fixedrange=True
+        ),
+        xaxis=dict(
+            fixedrange=True
+        ),
         height=240
     )
     return fig


### PR DESCRIPTION
The pie chart titles were getting cutoff so now they will appear on 2 lines if they are too long. Also fixed issues with the empty placeholder charts being too big and removed their interactivity.